### PR TITLE
Update windows-rs to 0.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-target = "x86_64-pc-windows-msvc"
 quick-xml = "0.23.0"
 
 [target."cfg(target_env = \"msvc\")".dependencies.windows]
-version = "0.39.0"
+version = "0.48.0"
 features = [
   "Win32_Foundation",
   "Foundation_Collections",
@@ -31,7 +31,7 @@ features = [
 ]
 
 [target."cfg(target_env = \"gnu\")".dependencies.windows]
-version = "0.39.0"
+version = "0.48.0"
 features = [
   "Win32_Foundation",
   "Foundation_Collections",


### PR DESCRIPTION
This update fixes the problem with `*-windows-gnullvm` targets: https://github.com/msys2/MINGW-packages/pull/17831#issuecomment-1657239946

Passed tests (saw the popup) on Windows 11 with `x86_64-pc-windows-gnu` target.