### PR TITLE
feat: add button support

### DIFF
--- a/.changes/buttons.md
+++ b/.changes/buttons.md
@@ -1,0 +1,5 @@
+---
+"tauri-winrt-notification": minor
+---
+
+Add support for adding buttons using `Toast::add_button`. This also comes with a change to `Toast::on_activated` wich will now take an `Option<String>` argument, containing which button was pressed if any.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,15 +13,18 @@ fn main() {
         .text1("(╯°□°）╯︵ ┻━┻")
         .sound(Some(Sound::SMS))
         .duration(Duration::Short)
-        .on_activated(handle_notification_click)
+        .on_activated(move |action| -> windows::core::Result<()> {
+            match action {
+                Some(action) => println!("You've clicked {}!", action),
+                None => println!("You've clicked me!"),
+            }
+            exit(0);
+        })
+        .add_button("Yes", "yes")
+        .add_button("No", "no")
         .show()
         .expect("unable to send notification");
     println!("Waiting 10 seconds for the notification to be clicked...");
     sleep(StdDuration::from_secs(10));
     println!("The notification wasn't clicked!");
-}
-
-fn handle_notification_click() -> windows::core::Result<()> {
-    println!("You've clicked me!");
-    exit(0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use windows::{
     UI::Notifications::{ToastActivatedEventArgs, ToastNotificationManager},
 };
 
+use std::fmt::Write
 use std::fmt::Display;
 use std::path::Path;
 use std::str::FromStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,16 +473,15 @@ impl Toast {
             }
         };
 
-        let actions = if !self.buttons.is_empty() {
-            let mut str = "<actions>".to_owned();
+        let actions = String::new();
+        if !self.buttons.is_empty() {
+            write!(actions, "<actions>");
             for b in &self.buttons {
-                str += &format!("<action content='{}' arguments='{}'/>", b.content, b.action);
+                write!(actions, "<action content='{}' arguments='{}'/>", b.content, b.action);
             }
-            str += "</actions>";
-            str
-        } else {
-            "".to_owned()
-        };
+            write!(actions, "</actions>");
+            actions 
+        }
 
         toast_xml.LoadXml(&HSTRING::from(format!(
             "<toast {} {}>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,15 +476,15 @@ impl Toast {
 
         let mut actions = String::new();
         if !self.buttons.is_empty() {
-            write!(actions, "<actions>");
+            let _ = write!(actions, "<actions>");
             for b in &self.buttons {
-                write!(
+                let _ = write!(
                     actions,
                     "<action content='{}' arguments='{}'/>",
                     b.content, b.action
                 );
             }
-            write!(actions, "</actions>");
+            let _ = write!(actions, "</actions>");
         }
 
         toast_xml.LoadXml(&HSTRING::from(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ impl Toast {
 
     /// Adds a button to the notification
     /// `content` is the text of the button.
-    /// `action` will be send as an argument on_activated when the button is clicked.
+    /// `action` will be send as an argument [on_activated](Self::on_activated) when the button is clicked.
     pub fn add_button(mut self, content: &str, action: &str) -> Toast {
         self.buttons.push(Button {
             content: content.to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ use windows::{
     UI::Notifications::{ToastActivatedEventArgs, ToastNotificationManager},
 };
 
-use std::fmt::Write;
 use std::fmt::Display;
+use std::fmt::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -474,7 +474,7 @@ impl Toast {
             }
         };
 
-        let actions = String::new();
+        let mut actions = String::new();
         if !self.buttons.is_empty() {
             write!(actions, "<actions>");
             for b in &self.buttons {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,10 +477,13 @@ impl Toast {
         if !self.buttons.is_empty() {
             write!(actions, "<actions>");
             for b in &self.buttons {
-                write!(actions, "<action content='{}' arguments='{}'/>", b.content, b.action);
+                write!(
+                    actions,
+                    "<action content='{}' arguments='{}'/>",
+                    b.content, b.action
+                );
             }
             write!(actions, "</actions>");
-            actions 
         }
 
         toast_xml.LoadXml(&HSTRING::from(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use windows::{
     UI::Notifications::{ToastActivatedEventArgs, ToastNotificationManager},
 };
 
-use std::fmt::Write
+use std::fmt::Write;
 use std::fmt::Display;
 use std::path::Path;
 use std::str::FromStr;


### PR DESCRIPTION
An option to add buttons to the notification.
Overview:  
```rust
Toast::new(Toast::POWERSHELL_APP_ID)
        .on_activated(move |action| -> windows::core::Result<()> {
            match action {
                Some(action) => println!("You've clicked {}!", action), // yes or no button was clicked
                None => println!("You've clicked me!"), // No action, body of the notification was clicked
            }
        })
        .add_button("Yes", "yes")
        .add_button("No", "no")

```