### PR TITLE
feat: add `on_dismissed` support

### DIFF
--- a/.changes/changefile.md
+++ b/.changes/changefile.md
@@ -1,0 +1,5 @@
+---
+"tauri-winrt-notification": patch
+---
+
+Add `Toast::on_dismissed` handler.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "githubPullRequests.upstreamRemote": "never"
+}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 # winrt-notification
 
-[![license](https://img.shields.io/crates/l/winrt-notification.svg)](https://crates.io/crates/winrt-notification/)
-[![version](https://img.shields.io/crates/v/winrt-notification.svg)](https://crates.io/crates/winrt-notification/)
-[![Build Status](https://img.shields.io/appveyor/ci/allenbenz/winrt-notification.svg)](https://ci.appveyor.com/project/allenbenz/winrt-notification)
+[![license](https://img.shields.io/crates/l/tauri-winrt-notification.svg)](https://crates.io/crates/tauri-winrt-notification/)
+[![documentation](https://img.shields.io/crates/v/tauri-winrt-notification?style=flat-square)](https://docs.rs/tauri-winrt-notification)
+
 
 An incomplete wrapper over the WinRT toast api
 
 Tested in Windows 10 and 8.1. Untested in Windows 8, might work.
 
-[0.5 Documentation](https://allenbenz.github.io/winrt-notification/0_5_0/winrt_notification/index.html)
-
-[0.2 Documentation](https://allenbenz.github.io/winrt-notification/0_2_0/winrt_notification/index.html)
-
 Todo:
 * Add support for Adaptive Content
-* Add support for Actions
 
 Known Issues:
 * Will not work for Windows 7.
@@ -27,14 +22,14 @@ Limitations:
 ```toml
 #Cargo.toml
 [dependencies]
-winrt-notification = "0.5.1"
+tauri-winrt-notification = "0.5.1"
 ```
 
 ## Examples
 
 ```rust
 extern crate winrt_notification;
-use winrt_notification::{Duration, Sound, Toast};
+use tauri_winrt_notification::{Duration, Sound, Toast};
 
 fn main() {
     Toast::new(Toast::POWERSHELL_APP_ID)
@@ -50,7 +45,7 @@ fn main() {
 ```rust
 extern crate winrt_notification;
 use std::path::Path;
-use winrt_notification::{IconCrop, Toast};
+use tauri_winrt_notification::{IconCrop, Toast};
 
 fn main() {
     Toast::new("Your AppUserModeId")

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,7 +5,7 @@
 
 use std::{process::exit, thread::sleep, time::Duration as StdDuration};
 
-use tauri_winrt_notification::{Duration, Sound, Toast};
+use tauri_winrt_notification::{Duration, Sound, Toast, ToastDismissalReason};
 
 fn main() {
     Toast::new(Toast::POWERSHELL_APP_ID)
@@ -22,8 +22,18 @@ fn main() {
         })
         .add_button("Yes", "yes")
         .add_button("No", "no")
+        .on_dismissed(|reason| {
+            match reason {
+                Some(ToastDismissalReason::UserCanceled) => println!("UserCanceled"),
+                Some(ToastDismissalReason::ApplicationHidden) => println!("ApplicationHidden"),
+                Some(ToastDismissalReason::TimedOut) => println!("TimedOut"),
+                _ => println!("Unknown"),
+            }
+            exit(0)
+        })
         .show()
         .expect("unable to send notification");
+
     println!("Waiting 10 seconds for the notification to be clicked...");
     sleep(StdDuration::from_secs(10));
     println!("The notification wasn't clicked!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! Todo:
 //!
 //! * Add support for Adaptive Content
-//! * Improve support for Actions
 //!
 //! Known Issues:
 //!
@@ -334,7 +333,7 @@ impl Toast {
             Duration::Long => "duration=\"long\"",
             Duration::Short => "duration=\"short\"",
         }
-        .to_owned();
+        .to_string();
         self
     }
 
@@ -349,7 +348,7 @@ impl Toast {
             Scenario::Reminder => "scenario=\"reminder\"",
             Scenario::IncomingCall => "scenario=\"incomingCall\"",
         }
-        .to_owned();
+        .to_string();
         self
     }
 
@@ -403,7 +402,7 @@ impl Toast {
     pub fn image(mut self, source: &Path, alt_text: &str) -> Toast {
         if !is_newer_than_windows81() {
             // win81 cannot have more than 1 image and shows nothing if there is more than that
-            self.images = "".to_owned();
+            self.images = String::new();
         }
         self.images = format!(
             r#"{}<image id="1" src="file:///{}" alt="{}" />"#,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! Todo:
 //!
 //! * Add support for Adaptive Content
-//! * Add support for Actions
+//! * Improve support for Actions
 //!
 //! Known Issues:
 //!
@@ -36,7 +36,9 @@ use windows::{
     core::{IInspectable, Interface},
     Data::Xml::Dom::XmlDocument,
     Foundation::TypedEventHandler,
-    UI::Notifications::{ToastActivatedEventArgs, ToastNotificationManager},
+    UI::Notifications::{
+        ToastActivatedEventArgs, ToastDismissedEventArgs, ToastNotificationManager,
+    },
 };
 
 use std::fmt::Display;
@@ -46,6 +48,14 @@ use std::str::FromStr;
 
 pub use windows::core::{Error, Result, HSTRING};
 pub use windows::UI::Notifications::ToastNotification;
+
+/// `ToastDismissalReason` is a struct representing the reason a toast notification was dismissed.
+///
+/// Variants:
+/// - `UserCanceled`: The user explicitly dismissed the toast notification.
+/// - `ApplicationHidden`: The application hid the toast notification programmatically.
+/// - `TimedOut`: The toast notification was dismissed because it timed out.
+pub use windows::UI::Notifications::ToastDismissalReason;
 
 pub struct Toast {
     duration: String,
@@ -57,6 +67,7 @@ pub struct Toast {
     app_id: String,
     scenario: String,
     on_activated: Option<TypedEventHandler<ToastNotification, IInspectable>>,
+    on_dismissed: Option<TypedEventHandler<ToastNotification, ToastDismissedEventArgs>>,
     buttons: Vec<Button>,
 }
 
@@ -276,6 +287,7 @@ impl Toast {
             app_id: app_id.to_string(),
             scenario: String::new(),
             on_activated: None,
+            on_dismissed: None,
             buttons: Vec::new(),
         }
     }
@@ -459,6 +471,49 @@ impl Toast {
         None
     }
 
+    /// Set the function to be called when the toast is dismissed
+    /// `f` will be called with the reason the toast was dismissed.
+    /// If the toast was dismissed by the user, the reason will be `ToastDismissalReason::UserCanceled`.
+    /// If the toast was dismissed by the application, the reason will be `ToastDismissalReason::ApplicationHidden`.
+    /// If the toast was dismissed because it timed out, the reason will be `ToastDismissalReason::TimedOut`.
+    /// If the reason is unknown, the reason will be `None`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use tauri_winrt_notification::{Toast, ToastDismissalReason};
+    ///
+    /// let toast = Toast::new(Toast::POWERSHELL_APP_ID);
+    /// toast.on_dismissed(|reason| {
+    ///     match reason {
+    ///         Some(ToastDismissalReason::UserCanceled) => println!("UserCanceled"),
+    ///         Some(ToastDismissalReason::ApplicationHidden) => println!("ApplicationHidden"),
+    ///         Some(ToastDismissalReason::TimedOut) => println!("TimedOut"),
+    ///         _ => println!("Unknown"),
+    ///     }
+    ///     Ok(())
+    /// }).show().expect("notification failed");
+    /// ```
+    pub fn on_dismissed<F: Fn(Option<ToastDismissalReason>) -> Result<()> + Send + 'static>(
+        mut self,
+        f: F,
+    ) -> Self {
+        self.on_dismissed = Some(TypedEventHandler::new(move |_, args| {
+            f(Self::get_dismissed_reason(args))
+        }));
+        self
+    }
+
+    fn get_dismissed_reason(
+        args: &Option<ToastDismissedEventArgs>,
+    ) -> Option<ToastDismissalReason> {
+        if let Some(args) = args {
+            if let Ok(reason) = args.Reason() {
+                return Some(reason);
+            }
+        }
+        None
+    }
+
     fn create_template(&self) -> windows::core::Result<ToastNotification> {
         //using this to get an instance of XmlDocument
         let toast_xml = XmlDocument::new()?;
@@ -518,6 +573,10 @@ impl Toast {
         let toast_template = self.create_template()?;
         if let Some(handler) = &self.on_activated {
             toast_template.Activated(handler)?;
+        }
+
+        if let Some(handler) = &self.on_dismissed {
+            toast_template.Dismissed(handler)?;
         }
 
         let toast_notifier =


### PR DESCRIPTION
Allow users to handle different dismissal reasons for toast notifications. 
`examples/simple.rs` has been updated to show usage.